### PR TITLE
Sprint 3 Team Contribution: Shared Favourites Context + Favourite from Movies Page

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -58,7 +58,6 @@
       "integrity": "sha512-H3mcG6ZDLTlYfaSNi0iOKkigqMFvkTKlGUYlD8GW7nNOYRrevuA46iTypPyv+06V3fEmvvazfntkBU34L0azAw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@babel/code-frame": "^7.28.6",
         "@babel/generator": "^7.28.6",
@@ -961,7 +960,6 @@
       "integrity": "sha512-+054pVMzVTmRQV8BhpGv3UyfZ2Llgl8rdpDTon+cUH9+na0ncBVXj3wTUKh14+Kiz18ziM3b4ikpP5/Pc0rQEQ==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "undici-types": "~7.16.0"
       }
@@ -972,7 +970,6 @@
       "integrity": "sha512-3MbSL37jEchWZz2p2mjntRZtPt837ij10ApxKfgmXCTuHWagYg7iA5bqPw6C8BMPfwidlvfPI/fxOc42HLhcyg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "csstype": "^3.2.2"
       }
@@ -1032,7 +1029,6 @@
       "integrity": "sha512-npiaib8XzbjtzS2N4HlqPvlpxpmZ14FjSJrteZpPxGUaYPlvhzlzUZ4mZyABo0EFrOWnvyd0Xxroq//hKhtAWg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "8.53.0",
         "@typescript-eslint/types": "8.53.0",
@@ -1284,7 +1280,6 @@
       "integrity": "sha512-NZyJarBfL7nWwIq+FDL6Zp/yHEhePMNnnJ0y3qfieCrmNvYct8uvtiV41UvlSe6apAfk0fY1FbWx+NwfmpvtTg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -1390,7 +1385,6 @@
         }
       ],
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "baseline-browser-mapping": "^2.9.0",
         "caniuse-lite": "^1.0.30001759",
@@ -1593,7 +1587,6 @@
       "integrity": "sha512-LEyamqS7W5HB3ujJyvi0HQK/dtVINZvd5mAAp9eT5S/ujByGjiZLCzPcHVzuXbpJDJF/cxwHlfceVUDZ2lnSTw==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.8.0",
         "@eslint-community/regexpp": "^4.12.1",
@@ -2541,7 +2534,6 @@
       "integrity": "sha512-5gTmgEY/sqK6gFXLIsQNH19lWb4ebPDLA4SdLP7dsWkIXHWlG66oPuVvXSGFPppYZz8ZDZq0dYYrbHfBCVUb1Q==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=12"
       },
@@ -2603,7 +2595,6 @@
       "resolved": "https://registry.npmjs.org/react/-/react-19.2.3.tgz",
       "integrity": "sha512-Ku/hhYbVjOQnXDZFv2+RibmLFGwFdeeKHFcOTlrt7xplBnya5OGn/hIRDsqDiSUcfORsDC7MPxwork8jBwsIWA==",
       "license": "MIT",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -2613,7 +2604,6 @@
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-19.2.3.tgz",
       "integrity": "sha512-yELu4WmLPw5Mr/lmeEpox5rw3RETacE++JgHqQzd2dg+YbJuat3jH4ingc+WPZhxaoFzdv9y33G+F7Nl5O0GBg==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "scheduler": "^0.27.0"
       },
@@ -2857,7 +2847,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"
@@ -2945,7 +2934,6 @@
       "integrity": "sha512-u09tdk/huMiN8xwoiBbig197jKdCamQTtOruSalOzbqGje3jdHiV0njQlAW0YvzoahkirFePNQ4RYlfnRQpXZA==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@oxc-project/runtime": "0.97.0",
         "fdir": "^6.5.0",
@@ -3068,7 +3056,6 @@
       "integrity": "sha512-k7Nwx6vuWx1IJ9Bjuf4Zt1PEllcwe7cls3VNzm4CQ1/hgtFUK2bRNG3rvnpPUhFjmqJKAKtjV576KnUkHocg/g==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/colinhacks"
       }

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,32 +1,16 @@
 import { Routes, Route } from "react-router-dom";
-import { useState } from "react";
 
 import HomePage from "./pages/HomePage";
 import MoviesPage from "./pages/MoviesPage";
-import TrendingPage from "./pages/TrendingPage";
+import NavigationBar from "./Components/navigation-bar/NavigationBar";
 import FavouritesPage from "./pages/FavouritesPage";
-import NavigationBar from "./components/navigation-bar/NavigationBar";
-
-const movies = [
-  {
-    title: "Avengers Endgame",
-    coverUrl: "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fimages-na.ssl-images-amazon.com%2Fimages%2FI%2F81%252BNup8-8NL._SL1500_.jpg&f=1&nofb=1&ipt=f93402e2b2791622fd05a4f9a05a8adfd94dad8f85a348ebdd400e2d99af99df",
-  },
-  {
-    title: "Inception",
-    coverUrl: "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fimages-na.ssl-images-amazon.com%2Fimages%2FI%2F81%252BNup8-8NL._SL1500_.jpg&f=1&nofb=1&ipt=f93402e2b2791622fd05a4f9a05a8adfd94dad8f85a348ebdd400e2d99af99df",
-  },
-];
 
 export default function App() {
   const links = [
     { label: "Home", url: "/" },
     { label: "Movies", url: "/movies" },
-    { label: "Favorites", url: "/favorites" },
-    { label: "Trending", url: "/trending" },
+    { label: "Favorites", url: "/favorites" }
   ];
-
-  const [count, setCount] = useState(0);
 
   return (
     <>
@@ -35,13 +19,8 @@ export default function App() {
       <Routes>
         <Route path="/" element={<HomePage />} />
         <Route path="/movies" element={<MoviesPage />} />
-        <Route path="/favorites" element={<FavouritesPage movies={movies} />} />
-        <Route path="/trending" element={<TrendingPage/>} />
+        <Route path="/favorites" element={<FavouritesPage />} />
       </Routes>
-
-      <div className="card">
-        <button onClick={() => setCount(count + 1)}>Count is {count}</button>
-      </div>
     </>
   );
 }

--- a/src/context/FavouritesContext.tsx
+++ b/src/context/FavouritesContext.tsx
@@ -1,0 +1,44 @@
+import { createContext, useContext, useState, type ReactNode } from "react";
+
+type FavouritesContextValue = {
+  favouriteIds: string[];
+  addFavourite: (id: string) => void;
+  removeFavourite: (id: string) => void;
+  isFavourite: (id: string) => boolean;
+};
+
+const FavouritesContext = createContext<FavouritesContextValue | undefined>(
+  undefined
+);
+
+export function FavouritesProvider({ children }: { children: ReactNode }) {
+  const [favouriteIds, setFavouriteIds] = useState<string[]>([]);
+
+  function addFavourite(id: string) {
+    setFavouriteIds((prev) => (prev.includes(id) ? prev : [id, ...prev]));
+  }
+
+  function removeFavourite(id: string) {
+    setFavouriteIds((prev) => prev.filter((x) => x !== id));
+  }
+
+  function isFavourite(id: string) {
+    return favouriteIds.includes(id);
+  }
+
+  return (
+    <FavouritesContext.Provider
+      value={{ favouriteIds, addFavourite, removeFavourite, isFavourite }}
+    >
+      {children}
+    </FavouritesContext.Provider>
+  );
+}
+
+export function useFavourites() {
+  const ctx = useContext(FavouritesContext);
+  if (!ctx) {
+    throw new Error("useFavourites must be used inside FavouritesProvider");
+  }
+  return ctx;
+}

--- a/src/hooks/useMovieSearch.ts
+++ b/src/hooks/useMovieSearch.ts
@@ -1,0 +1,18 @@
+import { useMemo, useState } from "react";
+import type { Movie } from "../types/movies";
+
+/**
+ * useMovieSearch
+ * Handles presentation logic for searching movies.
+ */
+export function useMovieSearch(movies: Movie[]) {
+  const [query, setQuery] = useState("");
+
+  const filteredMovies = useMemo(() => {
+    return movies.filter((m) =>
+      m.title.toLowerCase().includes(query.trim().toLowerCase())
+    );
+  }, [movies, query]);
+
+  return { query, setQuery, filteredMovies };
+}

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -3,6 +3,7 @@ import { createRoot } from "react-dom/client";
 import { BrowserRouter } from "react-router-dom";
 import App from "./App";
 import "./index.css";
+import { FavouritesProvider } from "./context/FavouritesContext";
 
 const rootElement = document.getElementById("root")!;
 const root = createRoot(rootElement);
@@ -10,7 +11,9 @@ const root = createRoot(rootElement);
 root.render(
   <StrictMode>
     <BrowserRouter>
-      <App />
+      <FavouritesProvider>
+        <App />
+      </FavouritesProvider>
     </BrowserRouter>
   </StrictMode>
 );

--- a/src/pages/FavouritesPage.tsx
+++ b/src/pages/FavouritesPage.tsx
@@ -3,31 +3,26 @@
  *
  * This component follows the hook-service-repository structure.
  *
- * The useMovies() hook handles presentation logic by loading movie data
- * into React state and keeping that state separate from the UI.
+ * useMovies() handles presentation logic by loading movie data.
  *
- * The movieService is used here for business logic, such as checking
- * whether a movie exists before adding it to favourites.
+ * movieService contains business logic (like validating movie titles).
  *
- * The movieService calls the movieRepository, which is responsible
- * for data access (currently using test data).
- *
- * This keeps presentation logic, business logic, and data access
- * separated as required in this sprint.
+ * Favourites are shared UI state using Context instead of prop drilling.
  */
+
 import { useState, type FormEvent } from "react";
 import { useMovies } from "../hooks/useMovies";
 import { movieService } from "../services/movieService";
-
+import { useFavourites } from "../context/FavouritesContext";
 
 export default function FavouritesPage() {
   const { movies } = useMovies();
+  const { favouriteIds, addFavourite, removeFavourite } = useFavourites();
 
-  const [favourites, setFavourites] = useState<string[]>([]);
   const [input, setInput] = useState("");
   const [message, setMessage] = useState<string>("");
 
-  function addFavourite(e: FormEvent) {
+  function handleAddByTitle(e: FormEvent) {
     e.preventDefault();
     setMessage("");
 
@@ -37,24 +32,20 @@ export default function FavouritesPage() {
       return;
     }
 
-    const check = movieService.canAddToFavourites(favourites, found.id);
-    if (!check.ok) {
-      setMessage(check.message || "Cannot add favourite.");
-      return;
-    }
-
-    setFavourites([found.id, ...favourites]);
+    addFavourite(found.id);
     setInput("");
     setMessage("Added.");
   }
 
-  const favouriteMovies = movies.filter((m) => favourites.includes(m.id));
+  const favouriteMovies = movies.filter((m) =>
+    favouriteIds.includes(m.id)
+  );
 
   return (
     <div>
       <h1>Favourites</h1>
 
-      <form onSubmit={addFavourite}>
+      <form onSubmit={handleAddByTitle}>
         <label htmlFor="favInput">Add by exact title</label>
         <input
           id="favInput"
@@ -67,6 +58,7 @@ export default function FavouritesPage() {
       {message && <p>{message}</p>}
 
       <h2>Your favourites</h2>
+
       {favouriteMovies.length === 0 ? (
         <p>No favourites yet.</p>
       ) : (
@@ -76,7 +68,7 @@ export default function FavouritesPage() {
               {m.title} ({m.year})
               <button
                 type="button"
-                onClick={() => setFavourites(favourites.filter((id) => id !== m.id))}
+                onClick={() => removeFavourite(m.id)}
                 style={{ marginLeft: 8 }}
               >
                 Remove

--- a/src/pages/MoviesPage.tsx
+++ b/src/pages/MoviesPage.tsx
@@ -1,40 +1,46 @@
+import { useState } from "react";
+import { useMovies } from "../hooks/useMovies";
+import { movieService } from "../services/movieService";
+import SearchPanel from "../Components/search-panel/SearchPanel";
+import { useFavourites } from "../context/FavouritesContext";
+
 /**
  * Sprint 3 - Architecture Usage
  *
  * This page uses the hook-service-repository structure.
  *
- * The useMovies() hook handles presentation logic by loading
- * the movie data into state for this page.
+ * useMovies -> presentation logic
+ * movieService -> business logic
+ * repository -> data access
  *
- * The hook calls movieService, which contains the business logic
- * for working with movies.
- *
- * The service then uses movieRepository for data access
- * (right now using test data).
- *
- * This keeps business logic and presentation logic separate
- * instead of putting everything in the component.
+ * Favourites are shared UI state using Context.
  */
-import { useState } from "react";
-import { useMovies } from "../hooks/useMovies";
-import { movieService } from "../services/movieService";
-import MovieList from "../components/movie-list/MovieList";
-import SearchPanel from "../components/search-panel/SearchPanel";
-
 
 export default function MoviesPage() {
-  const movies = [
-  {
-    id: "1",
-    title: "Inception",
-    coverUrl: "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fimages-na.ssl-images-amazon.com%2Fimages%2FI%2F81%252BNup8-8NL._SL1500_.jpg&f=1&nofb=1&ipt=f93402e2b2791622fd05a4f9a05a8adfd94dad8f85a348ebdd400e2d99af99df",
-  },
-  {
-    id: "2",
-    title: "Interstellar",
-    coverUrl: "https://external-content.duckduckgo.com/iu/?u=https%3A%2F%2Fimages-na.ssl-images-amazon.com%2Fimages%2FI%2F81%252BNup8-8NL._SL1500_.jpg&f=1&nofb=1&ipt=f93402e2b2791622fd05a4f9a05a8adfd94dad8f85a348ebdd400e2d99af99df",
-  },
-];
+  const { movies, refresh } = useMovies();
+  const { addFavourite, removeFavourite, isFavourite } = useFavourites();
+
+  const [query, setQuery] = useState("");
+
+  const filtered = movies.filter((m) =>
+    m.title.toLowerCase().includes(query.trim().toLowerCase())
+  );
+
+  function addTestMovie() {
+    const result = movieService.addMovie({
+      id: "m" + Date.now(),
+      title: "Test Movie " + Math.floor(Math.random() * 100),
+      year: 2024,
+      coverUrl: "https://via.placeholder.com/150?text=New+Movie",
+    });
+
+    if (result.ok) {
+      refresh();
+    } else {
+      alert(result.message || "Could not add movie.");
+    }
+  }
+
   return (
     <div>
       <h1>Movies</h1>
@@ -50,7 +56,22 @@ export default function MoviesPage() {
         totalCount={movies.length}
       />
 
-      <MovieList movies={filtered} />
+      <ul>
+        {filtered.map((m) => (
+          <li key={m.id} style={{ marginBottom: 8 }}>
+            {m.title} ({m.year}){" "}
+            {isFavourite(m.id) ? (
+              <button onClick={() => removeFavourite(m.id)}>
+                Remove Favourite
+              </button>
+            ) : (
+              <button onClick={() => addFavourite(m.id)}>
+                Add Favourite
+              </button>
+            )}
+          </li>
+        ))}
+      </ul>
     </div>
   );
 }


### PR DESCRIPTION
This PR adds a way to favourite movies directly from the Movies page.

I created a FavouritesContext to share favourite state between pages instead of passing props (as discussed in lecture about avoiding prop drilling).

Movies still use the hook–service–repository structure:
- useMovies handles presentation logic
- movieService handles business logic
- movieRepository handles data access

Favourites are shared UI state, so I used Context like we learned in class.

This improves shared page state (T.4) and supports the team requirements.